### PR TITLE
Stop using the API to test if the wiki is up and running

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -38,9 +38,9 @@ echowarn() {
 }
 
 check_service() {
-    echoinfo "curl http://localhost/api/rest_v1/page/html/Main_Page"
+    echoinfo "curl http://localhost/index.php/Main_Page"
     # Make sure that the wiki is reachable & RESTBase works
-    curl http://localhost/api/rest_v1/page/html/Main_Page \
+    curl http://localhost/index.php/Main_Page \
         | grep -q "MediaWiki has been successfully installed"
 }
 


### PR DESCRIPTION
As shown here (https://www.mediawiki.org/api/rest_v1/#!/Page_content/get_page_html_title), the API is unstable, which currently results in the test failing even though the wiki is up.
Checking the page directly works as intended.