### PR TITLE
Fix the value of MEDIAWIKI_RESTBASE_URL

### DIFF
--- a/k8s-alpha.yml
+++ b/k8s-alpha.yml
@@ -34,7 +34,7 @@ spec:
             - name: MEDIAWIKI_DB_HOST
               value: 127.0.0.1
             - name: MEDIAWIKI_RESTBASE_URL
-              value: http://localhost:7231/api/rest_v1
+              value: http://localhost:7231/localhost/v1
           volumeMounts:
             - name: mediawiki-storage
               mountPath: /data


### PR DESCRIPTION
We can either use `localhost:7231/{{domain}}/v1` or the apache redirect
set up for `localhost/api/rest_v1`, but `localhost:7231/api/rest_v1` doesn't
exist.