### PR TITLE
First step towards services & inline configmaps

### DIFF
--- a/README.k8s.md
+++ b/README.k8s.md
@@ -1,7 +1,7 @@
 # WIP Kubernetes setup instructions
 
-1) Set up minikube (also see optional / experimental native Linux support
-instructions below).
+1) Set up [minikube](https://github.com/kubernetes/minikube) (also see
+optional / experimental native Linux support instructions below).
 2) Start the mediawiki-containers Kubernetes cluster. From within the minikube
 environment (native shell when using native Docker):
 
@@ -11,13 +11,8 @@ git clone git@github.com:wikimedia/mediawiki-containers.git
 cd mediawiki-containers
 git checkout k8s
 
-# Load the MediaWiki configuration into kubernetes
-kubectl create configmap mediawiki-conf-1 --from-file=conf/mediawiki
-
 # start cluster
-kubectl create -f k8s-alpha.yml
-# expose as service
-kubectl expose deployment mediawiki-basic --type=NodePort
+kubectl apply -f k8s-alpha.yml
 
 # find the minikube IP
 minikube ip

--- a/k8s-alpha.yml
+++ b/k8s-alpha.yml
@@ -80,6 +80,9 @@ spec:
 
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mediawiki-conf-1
 data:
   CustomSettings.php: |
     <?php
@@ -96,9 +99,13 @@ data:
       'forwardCookies' => true,
       'parsoidCompat' => false
     );
-kind: ConfigMap
-metadata:
-  name: mediawiki-conf-1
+
+    /**
+     * Math
+     */
+    $wgDefaultUserOptions['math'] = 'mathml';
+    $wgMathFullRestbaseURL = 'http://localhost:7231/localhost/';
+    wfLoadExtension( 'Math' );
 
 ---
 apiVersion: v1

--- a/k8s-alpha.yml
+++ b/k8s-alpha.yml
@@ -1,13 +1,13 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: mediawiki-basic
+  name: mediawiki-pod
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        service_name: mediawiki-services
+        service_name: mediawiki
     spec:
       containers:
         - name: mediawiki
@@ -72,3 +72,39 @@ spec:
         - name: mediawiki-conf
           configMap:
             name: mediawiki-conf-1
+
+---
+apiVersion: v1
+data:
+  CustomSettings.php: |
+    <?php
+    
+    /**
+     * VisualEditor
+     */
+    require_once "/usr/src/mediawiki/extensions/VisualEditor/VisualEditor.php";
+    $wgDefaultUserOptions['visualeditor-enable'] = 1;
+    $wgHiddenPrefs[] = 'visualeditor-enable';
+    $wgVirtualRestConfig['modules']['restbase'] = array(
+      'url' => 'http://localhost:7231',
+      'domain' => 'localhost',
+      'forwardCookies' => true,
+      'parsoidCompat' => false
+    );
+kind: ConfigMap
+metadata:
+  name: mediawiki-conf-1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mediawiki-svc
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    service_name: mediawiki


### PR DESCRIPTION
- Set up the MediaWiki configmap right in the main config file.
- Set up a service to expose port 80 of the MW pod.
- Update README mit simplified procedure, using `kubectl apply`
exclusively.

Next step: Move mysql and services to separate pods & services.