### PR TITLE
Move to k8s services

### DIFF
--- a/README.k8s.md
+++ b/README.k8s.md
@@ -1,7 +1,7 @@
 # WIP Kubernetes setup instructions
 
-1) Set up minikube (also see optional / experimental native Linux support
-instructions below).
+1) Set up [minikube](https://github.com/kubernetes/minikube) (also see
+optional / experimental native Linux support instructions below).
 2) Start the mediawiki-containers Kubernetes cluster. From within the minikube
 environment (native shell when using native Docker):
 
@@ -11,13 +11,8 @@ git clone git@github.com:wikimedia/mediawiki-containers.git
 cd mediawiki-containers
 git checkout k8s
 
-# Load the MediaWiki configuration into kubernetes
-kubectl create configmap mediawiki-conf-1 --from-file=conf/mediawiki
-
 # start cluster
-kubectl create -f k8s-alpha.yml
-# expose as service
-kubectl expose deployment mediawiki-basic --type=NodePort
+kubectl apply -f k8s-alpha.yml
 
 # find the minikube IP
 minikube ip

--- a/k8s-alpha.yml
+++ b/k8s-alpha.yml
@@ -80,6 +80,9 @@ spec:
 
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mediawiki-conf-1
 data:
   CustomSettings.php: |
     <?php
@@ -96,9 +99,13 @@ data:
       'forwardCookies' => true,
       'parsoidCompat' => false
     );
-kind: ConfigMap
-metadata:
-  name: mediawiki-conf-1
+
+    /**
+     * Math
+     */
+    $wgDefaultUserOptions['math'] = 'mathml';
+    $wgMathFullRestbaseURL = 'http://localhost:7231/localhost/';
+    wfLoadExtension( 'Math' );
 
 ---
 apiVersion: v1

--- a/k8s-alpha.yml
+++ b/k8s-alpha.yml
@@ -1,7 +1,83 @@
+# BEGIN MySQL
+
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: mediawiki-pod
+  name: mysql-deploy
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        service_name: mysql
+    spec:
+      containers:
+        - name: mysql
+          image: mariadb
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: password
+          volumeMounts:
+            - name: mysql-storage
+              mountPath: /var/lib/mysql
+
+      volumes:
+        - name: mysql-storage
+          hostPath:
+            path: /var/lib/mediawiki-containers/mysql
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-svc
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3306
+  selector:
+    service_name: mysql
+
+# END MySQL
+
+---
+# BEGIN MediaWiki
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mediawiki-conf-1
+data:
+  CustomSettings.php: |
+    <?php
+    
+    /**
+     * VisualEditor
+     */
+    wfLoadExtension( 'VisualEditor' );
+
+    $wgDefaultUserOptions['visualeditor-enable'] = 1;
+    $wgHiddenPrefs[] = 'visualeditor-enable';
+    $wgVirtualRestConfig['modules']['restbase'] = array(
+      'url' => 'http://restbase-svc:7231',
+      'domain' => 'localhost',
+      'forwardCookies' => true,
+      'parsoidCompat' => false
+    );
+
+    /**
+     * Math
+     */
+    #wfLoadExtension( 'Math' );
+    #$wgMathValidModes[] = 'mathml';
+    #$wgDefaultUserOptions['math'] = 'mathml';
+    #$wgMathFullRestbaseURL = 'http://restbase-svc:7231/localhost/';
+    #unset($GLOBALS['wgMathMathMLUrl']);
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: mediawiki-deploy
 spec:
   replicas: 1
   template:
@@ -11,7 +87,7 @@ spec:
     spec:
       containers:
         - name: mediawiki
-          image: wikimedia/mediawiki
+          image: wikimedia/mediawiki:1.30.0-wmf3
           ports:
             - containerPort: 80
           env:
@@ -27,85 +103,29 @@ spec:
               value: admin
             - name: MEDIAWIKI_UPDATE
               value: 'true'
+            - name: MEDIAWIKI_DB_TYPE
+              value: mysql
             - name: MEDIAWIKI_DB_USER
               value: root
             - name: MEDIAWIKI_DB_PASSWORD
               value: password
             - name: MEDIAWIKI_DB_HOST
-              value: 127.0.0.1
+              value: mysql-svc
             - name: MEDIAWIKI_RESTBASE_URL
-              value: http://localhost:7231/api/rest_v1
+              value: http://restbase-svc:7231/localhost/v1
           volumeMounts:
             - name: mediawiki-storage
               mountPath: /data
             - name: mediawiki-conf
               mountPath: /conf
 
-        - name: mediawiki-node-services
-          image: wikimedia/mediawiki-node-services:0.2.1
-          env:
-            - name: MEDIAWIKI_API_URL
-              value: http://localhost/api.php
-          volumeMounts:
-            - name: node-services-storage
-              mountPath: /data
-
-        - name: mathoid
-          image: wikimedia/mathoid:24b660f09
-          ports:
-            - containerPort: 10044
-
-        - name: mysql
-          image: mariadb
-          env:
-            - name: MYSQL_ROOT_PASSWORD
-              value: password
-          volumeMounts:
-            - name: mysql-storage
-              mountPath: /var/lib/mysql
-
       volumes:
-        - name: node-services-storage
-          hostPath:
-            path: /var/lib/mediawiki-containers/node-services
         - name: mediawiki-storage
           hostPath:
             path: /var/lib/mediawiki-containers/mediawiki
-        - name: mysql-storage
-          hostPath:
-            path: /var/lib/mediawiki-containers/mysql
         - name: mediawiki-conf
           configMap:
             name: mediawiki-conf-1
-
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: mediawiki-conf-1
-data:
-  CustomSettings.php: |
-    <?php
-    
-    /**
-     * VisualEditor
-     */
-    require_once "/usr/src/mediawiki/extensions/VisualEditor/VisualEditor.php";
-    $wgDefaultUserOptions['visualeditor-enable'] = 1;
-    $wgHiddenPrefs[] = 'visualeditor-enable';
-    $wgVirtualRestConfig['modules']['restbase'] = array(
-      'url' => 'http://localhost:7231',
-      'domain' => 'localhost',
-      'forwardCookies' => true,
-      'parsoidCompat' => false
-    );
-
-    /**
-     * Math
-     */
-    $wgDefaultUserOptions['math'] = 'mathml';
-    $wgMathFullRestbaseURL = 'http://localhost:7231/localhost/';
-    wfLoadExtension( 'Math' );
 
 ---
 apiVersion: v1
@@ -120,3 +140,80 @@ spec:
     targetPort: 80
   selector:
     service_name: mediawiki
+
+# END MediaWiki
+---
+# BEGIN RESTBase
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: restbase-deploy
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        service_name: restbase
+    spec:
+      containers:
+        - name: mediawiki-node-services
+          image: wikimedia/mediawiki-node-services:0.2.1
+          env:
+            - name: MEDIAWIKI_API_URL
+              value: http://mediawiki-svc/api.php
+          volumeMounts:
+            - name: node-services-storage
+              mountPath: /data
+
+      volumes:
+        - name: node-services-storage
+          hostPath:
+            path: /var/lib/mediawiki-containers/node-services
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: restbase-svc
+spec:
+  type: ClusterIP
+  ports:
+  - port: 7231
+    protocol: TCP
+  selector:
+    service_name: restbase
+
+# END RESTBase
+
+---
+# BEGIN Mathoid
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: mathoid-deploy
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        service_name: mathoid
+    spec:
+      containers:
+        - name: mathoid
+          image: wikimedia/mathoid:24b660f09
+          ports:
+            - containerPort: 10044
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mathoid-svc
+spec:
+  type: ClusterIP
+  ports:
+  - port: 10044
+    protocol: TCP
+  selector:
+    service_name: mathoid
+
+# END Mathoid
+

--- a/k8s-alpha.yml
+++ b/k8s-alpha.yml
@@ -1,13 +1,13 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: mediawiki-basic
+  name: mediawiki-pod
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        service_name: mediawiki-services
+        service_name: mediawiki
     spec:
       containers:
         - name: mediawiki
@@ -72,3 +72,39 @@ spec:
         - name: mediawiki-conf
           configMap:
             name: mediawiki-conf-1
+
+---
+apiVersion: v1
+data:
+  CustomSettings.php: |
+    <?php
+    
+    /**
+     * VisualEditor
+     */
+    require_once "/usr/src/mediawiki/extensions/VisualEditor/VisualEditor.php";
+    $wgDefaultUserOptions['visualeditor-enable'] = 1;
+    $wgHiddenPrefs[] = 'visualeditor-enable';
+    $wgVirtualRestConfig['modules']['restbase'] = array(
+      'url' => 'http://localhost:7231',
+      'domain' => 'localhost',
+      'forwardCookies' => true,
+      'parsoidCompat' => false
+    );
+kind: ConfigMap
+metadata:
+  name: mediawiki-conf-1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mediawiki-svc
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    service_name: mediawiki

--- a/mediawiki-containers
+++ b/mediawiki-containers
@@ -87,8 +87,8 @@ start () {
         -e MEDIAWIKI_ADMIN_PASS=$MEDIAWIKI_ADMIN_PASS \
         -e MEDIAWIKI_UPDATE=true \
         -e MEDIAWIKI_DB_USER=root \
-        -e MEDIAWIKI_DB_HOST=mysql.docker \
         -e MEDIAWIKI_DB_PASSWORD=password \
+        -e MEDIAWIKI_DB_HOST=mysql.docker \
         -e MEDIAWIKI_RESTBASE_URL=http://mediawiki-node-services.docker:7231/localhost/v1 \
         --dns "$DNS" \
         -p 80:80 \


### PR DESCRIPTION
- Move each service to its own deployment, and access it through a dedicated service object. This is closer to what we'll have in production, and will let us scale up replicas for each service independently. It also makes it possible to use multiple nodes.
- Disable the math extension in the config until it is fully configured.
- Update the used mediawiki image to 1.30.0-wmf3, which also includes a checkout of the math extension.