### PR TITLE
Use empty string for MEDIAWIKI_SITE_SERVER

### DIFF
--- a/k8s-alpha.yml
+++ b/k8s-alpha.yml
@@ -97,7 +97,7 @@ spec:
             - containerPort: 80
           env:
             - name: MEDIAWIKI_SITE_SERVER
-              value: /
+              value: ''
             - name: MEDIAWIKI_SITE_NAME
               value: MediaWiki
             - name: MEDIAWIKI_SITE_LANG


### PR DESCRIPTION
MW appends a slash to the server, so we don't need to set one ourselves.