### PR TITLE
MW config: Enable basic caching in the database

### DIFF
--- a/k8s-alpha.yml
+++ b/k8s-alpha.yml
@@ -54,6 +54,9 @@ data:
     $wgArticlePath = '/wiki/$1';
     $wgScriptPath = '/w';
 
+    # Enable database caching
+    $wgMainCacheType = CACHE_DB;
+
     /**
      * VisualEditor
      */


### PR DESCRIPTION
MediaWiki's performance relies on caching to a significant degree. By
default, LocalSettings disables any caching, which is bad for
performance.

This patch sets the cache backend to the database, which is a safe
default. In the future, we can consider enabling PHP caching or
memcached instead.