### PR TITLE
Reset on-disk config to old master state

### DIFF
--- a/conf/mediawiki/CustomSettings.php
+++ b/conf/mediawiki/CustomSettings.php
@@ -7,18 +7,12 @@ require_once "/usr/src/mediawiki/extensions/VisualEditor/VisualEditor.php";
 $wgDefaultUserOptions['visualeditor-enable'] = 1;
 $wgHiddenPrefs[] = 'visualeditor-enable';
 #$wgDefaultUserOptions['visualeditor-enable-experimental'] = 1;
-$wgVirtualRestConfig['modules']['restbase'] = array(
-	'url' => 'http://localhost:7231',
+$wgVirtualRestConfig['modules']['parsoid'] = array(
+	// URL to the Parsoid instance
+	// Use port 8142 if you use the Debian package
+	'url' => 'http://mediawiki-node-services.docker:8142',
+	// Parsoid "domain", see below (optional)
 	'domain' => 'localhost',
-	'forwardCookies' => true,
-	'parsoidCompat' => false
+	// Parsoid "prefix", see below (optional)
+	'prefix' => 'localhost'
 );
-
-/**
- * Math
- */
-$wgDefaultUserOptions['math'] = 'mathml';
-$wgMathFullRestbaseURL = 'http://localhost:7231/localhost/';
-wfLoadExtension( 'Math' );
-
-?>


### PR DESCRIPTION
The Kubernetes setup does not use this on-disk config file any more, so
there is no reason to update it any more. This is also the only
difference from master, so resetting this to the state expected by
master lets us merge the k8s branch to master without breaking existing
users.